### PR TITLE
Re-add Filebrowser

### DIFF
--- a/filebrowser.js
+++ b/filebrowser.js
@@ -1,0 +1,29 @@
+function wrFilebrowser (callback, value, meta) {
+    var cmsURL = "%URL%";
+    var type = meta.filetype;
+
+    if (type == "file") {
+        type = "downloads"
+    };
+
+    if (cmsURL.indexOf("?") < 0) {
+        cmsURL = cmsURL + "?type="+ type;
+    } else {
+        cmsURL = cmsURL + "&type=" + type;
+    }
+
+    // FIXME: avoid the following two global variables!
+    filebrowsercallback = callback;
+    filebrowserwindow = tinymce.activeEditor.windowManager.open({
+        title: "File Manager",
+        body: {
+            type: "panel",
+            items: [{
+                type: "htmlpanel",
+                html: '<iframe src="' + cmsURL + '" style="width:100%; height:100%"></iframe>'
+            }]
+        },
+        buttons: []
+    });
+    return false;
+}

--- a/inits/init_tinymce5.js
+++ b/inits/init_tinymce5.js
@@ -7,7 +7,7 @@
   plugins: [
     "advlist anchor autolink autoresize autosave charmap code emoticons fullscreen help hr",
     "image imagetools importcss insertdatetime link lists media nonbreaking paste",
-    "save searchreplace table tinydrive visualblocks visualchars wordcount noneditable"
+    "save searchreplace table visualblocks visualchars wordcount noneditable"
   ],
   toolbar: [
     'save | fullscreen | undo redo | styleselect | bold italic | link image',
@@ -16,7 +16,7 @@
   autosave_interval: "20s",
   image_advtab: true,
   image_title: true,
-  tinydrive_token_provider: "%CMSIMPLE_ROOT%?tinydrive=requesttoken",
+  file_picker_callback: "%FILEBROWSER_CALLBACK%",
   content_css: "%STYLESHEET%,%CMSIMPLE_ROOT%plugins/fa/css/font-awesome.min.css",
   importcss_append:true,
   style_formats_autohide: true,


### PR DESCRIPTION
The filebrowser dialog should be opened maximized, like the source code
dialog – how?

The global variables `filebrowsercallback` and `filebrowserwindow`
should be avoided – how?

All in all, somewhat hackish, but working. :)